### PR TITLE
From Custom Result to Kotlin Result

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,9 @@ android {
     buildFeatures {
         dataBinding true
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -48,10 +51,10 @@ dependencies {
     implementation "com.google.code.gson:gson:2.9.0"
 
     // repeatLifeCycle
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.0-beta01'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.0-rc01'
 
     // Coil
-    implementation "io.coil-kt:coil:2.0.0-rc03"
+    implementation "io.coil-kt:coil:2.1.0"
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     // navigation
@@ -71,12 +74,17 @@ dependencies {
     kapt "com.google.dagger:hilt-android-compiler:2.40"
 
     // liveData
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.5.0-alpha06"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.5.0-rc01"
+
+    // Optional -- Robolectric environment
+    testImplementation 'androidx.test:core:1.4.0'
+    // Optional -- Mockito framework
+    testImplementation 'org.mockito:mockito-core:4.2.0'
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'com.google.android.material:material:1.6.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/example/sopt_seminar/data/api/ApiService.kt
+++ b/app/src/main/java/com/example/sopt_seminar/data/api/ApiService.kt
@@ -18,12 +18,12 @@ interface ApiService {
     @POST(SIGN_UP)
     suspend fun signUp(
         @Body signUpRequest: SignUpRequest
-    ): Response<CommonResponse<DataResponse.SignUp>>
+    ): CommonResponse<DataResponse.SignUp>
 
     @POST(SIGN_IN)
     suspend fun signIn(
         @Body signInRequest: SignInRequest
-    ): Response<CommonResponse<DataResponse.SignIn>>
+    ): CommonResponse<DataResponse.SignIn>
 
     @GET(GITHUB_USER_FOLLOWERS)
     suspend fun getFollowerList(

--- a/app/src/main/java/com/example/sopt_seminar/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/sopt_seminar/data/repository/UserRepositoryImpl.kt
@@ -1,14 +1,10 @@
 package com.example.sopt_seminar.data.repository
 
-import com.example.sopt_seminar.data.api.response.ErrorResponse
 import com.example.sopt_seminar.data.entity.toFollower
 import com.example.sopt_seminar.data.source.local.UserLocalDatSource
 import com.example.sopt_seminar.data.source.remote.UserRemoteDataSource
 import com.example.sopt_seminar.domain.model.Follower
 import com.example.sopt_seminar.domain.repository.UserRepository
-import com.example.sopt_seminar.domain.state.Result
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
@@ -16,53 +12,45 @@ class UserRepositoryImpl @Inject constructor(
     private val userLocalDatSource: UserLocalDatSource,
     private val userRemoteDataSource: UserRemoteDataSource
 ) : UserRepository {
-    private val gson = Gson()
-    private val type = object : TypeToken<ErrorResponse>() {}.type
-
     override suspend fun isAutoLogin(): Flow<Boolean> = userLocalDatSource.isAutoLogin()
 
     override suspend fun setAutoLogin(isAutoLogin: Boolean) {
         userLocalDatSource.setAutoLogin(isAutoLogin)
     }
 
-    override suspend fun signUp(userName: String, userEmail: String, userPassword: String): Result {
-        val response = userRemoteDataSource.signUpUser(userName, userEmail, userPassword)
-
-        return if (response.isSuccessful) {
-            val msg = "성공 ${response.body()?.message} 코드: ${response.body()?.status}"
-            Result.Success(msg)
-        } else {
-            val errorResponse: ErrorResponse? =
-                gson.fromJson(response.errorBody()!!.charStream(), type)
-            val msg = "실패 ${errorResponse?.message} 코드: ${errorResponse?.status}"
-            Result.Fail(msg)
-        }
+    override suspend fun signUp(
+        userName: String,
+        userEmail: String,
+        userPassword: String
+    ): Result<String> {
+        runCatching { userRemoteDataSource.signUpUser(userName, userEmail, userPassword) }
+            .onSuccess { return Result.success("${it.success} message: ${it.message})") }
+            .onFailure { return Result.failure(Throwable("이미 존재하는 유저")) }
+        return Result.failure(Throwable("what the...f"))
     }
 
-    override suspend fun signIn(userEmail: String, userPassword: String): Result {
-        val response = userRemoteDataSource.signInUser(userEmail, userPassword)
-
-        return if (response.isSuccessful) {
-            val msg = "성공 ${response.body()?.message} 코드: ${response.body()?.status}"
-            Result.Success(msg)
-        } else {
-            val errorResponse: ErrorResponse? =
-                gson.fromJson(response.errorBody()!!.charStream(), type)
-            val msg = "실패 ${errorResponse?.message} 코드: ${errorResponse?.status}"
-            Result.Fail(msg)
-        }
+    override suspend fun signIn(userEmail: String, userPassword: String): Result<String> {
+        runCatching { userRemoteDataSource.signInUser(userEmail, userPassword) }
+            .onSuccess { return Result.success("${it.success} message: ${it.message})") }
+            .onFailure { error ->
+                return when (error.message) {
+                    NOT_FOUND -> Result.failure(Throwable("유저 정보를 찾을 수 없습니다"))
+                    else -> Result.failure(Throwable("비밀번호가 올바르지 않음"))
+                }
+            }
+        return Result.failure(Throwable("what the...f"))
     }
 
-    override suspend fun getFollowerList(): Result {
-        val response = userRemoteDataSource.getFollowerList()
+    override suspend fun getFollowerList(): Result<List<Follower>> {
+        runCatching { userRemoteDataSource.getFollowerList() }
+            .onSuccess { response ->
+                return Result.success(response.body()!!.map { followerEntity -> followerEntity.toFollower() })
+            }
+            .onFailure { return Result.failure(Throwable(it)) }
+        return Result.failure(Throwable("what the...f"))
+    }
 
-        return if (response.isSuccessful) {
-            val followerList: List<Follower> = response.body()?.map { followerEntity ->
-                followerEntity.toFollower()
-            }!!
-            Result.Success(followerList)
-        } else {
-            Result.Fail(response.errorBody()?.string())
-        }
+    companion object {
+        const val NOT_FOUND = "HTTP 404 Not Found"
     }
 }

--- a/app/src/main/java/com/example/sopt_seminar/data/source/remote/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/example/sopt_seminar/data/source/remote/UserRemoteDataSource.kt
@@ -10,12 +10,12 @@ interface UserRemoteDataSource {
         userName: String,
         userEmail: String,
         userPassword: String
-    ): Response<CommonResponse<DataResponse.SignUp>>
+    ): CommonResponse<DataResponse.SignUp>
 
     suspend fun signInUser(
         userEmail: String,
         userPassword: String,
-    ): Response<CommonResponse<DataResponse.SignIn>>
+    ): CommonResponse<DataResponse.SignIn>
 
     suspend fun getFollowerList(): Response<List<FollowerEntity>>
 }

--- a/app/src/main/java/com/example/sopt_seminar/data/source/remote/UserRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/sopt_seminar/data/source/remote/UserRemoteDataSourceImpl.kt
@@ -16,7 +16,7 @@ class UserRemoteDataSourceImpl @Inject constructor(
         userName: String,
         userEmail: String,
         userPassword: String
-    ): Response<CommonResponse<DataResponse.SignUp>> {
+    ): CommonResponse<DataResponse.SignUp> {
         return apiService.signUp(
             SignUpRequest(
                 name = userName,
@@ -29,7 +29,7 @@ class UserRemoteDataSourceImpl @Inject constructor(
     override suspend fun signInUser(
         userEmail: String,
         userPassword: String,
-    ): Response<CommonResponse<DataResponse.SignIn>> {
+    ): CommonResponse<DataResponse.SignIn> {
         return apiService.signIn(
             SignInRequest(
                 email = userEmail,

--- a/app/src/main/java/com/example/sopt_seminar/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/sopt_seminar/domain/repository/UserRepository.kt
@@ -1,6 +1,6 @@
 package com.example.sopt_seminar.domain.repository
 
-import com.example.sopt_seminar.domain.state.Result
+import com.example.sopt_seminar.domain.model.Follower
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
@@ -10,12 +10,12 @@ interface UserRepository {
         userName: String,
         userEmail: String,
         userPassword: String
-    ): Result
+    ): Result<String>
 
     suspend fun signIn(
         userEmail: String,
         userPassword: String,
-    ): Result
+    ): Result<String>
 
-    suspend fun getFollowerList(): Result
+    suspend fun getFollowerList(): Result<List<Follower>>
 }

--- a/app/src/main/java/com/example/sopt_seminar/domain/state/Result.kt
+++ b/app/src/main/java/com/example/sopt_seminar/domain/state/Result.kt
@@ -1,7 +1,0 @@
-package com.example.sopt_seminar.domain.state
-
-sealed class Result {
-    object Uninitialized : Result()
-    data class Success<T>(val data: T) : Result()
-    data class Fail<T>(val msg: T) : Result()
-}

--- a/app/src/main/java/com/example/sopt_seminar/domain/usecase/GetFollowerListUseCase.kt
+++ b/app/src/main/java/com/example/sopt_seminar/domain/usecase/GetFollowerListUseCase.kt
@@ -1,17 +1,11 @@
 package com.example.sopt_seminar.domain.usecase
 
+import com.example.sopt_seminar.domain.model.Follower
 import com.example.sopt_seminar.domain.repository.UserRepository
-import com.example.sopt_seminar.domain.state.Result
 import javax.inject.Inject
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 
 class GetFollowerListUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(): Flow<Result> = flow {
-        emit(Result.Uninitialized)
-        emit(userRepository.getFollowerList())
-    }
+    suspend operator fun invoke(): Result<List<Follower>> = userRepository.getFollowerList()
 }

--- a/app/src/main/java/com/example/sopt_seminar/domain/usecase/SignInUseCase.kt
+++ b/app/src/main/java/com/example/sopt_seminar/domain/usecase/SignInUseCase.kt
@@ -2,7 +2,6 @@ package com.example.sopt_seminar.domain.usecase
 
 import com.example.sopt_seminar.domain.repository.UserRepository
 import javax.inject.Inject
-import com.example.sopt_seminar.domain.state.Result
 
 class SignInUseCase @Inject constructor(
     private val userRepository: UserRepository
@@ -10,7 +9,7 @@ class SignInUseCase @Inject constructor(
     suspend operator fun invoke(
         userEmail: String,
         userPassword: String
-    ): Result = userRepository.signIn(
+    ): Result<String> = userRepository.signIn(
         userEmail,
         userPassword
     )

--- a/app/src/main/java/com/example/sopt_seminar/domain/usecase/SignUpUseCase.kt
+++ b/app/src/main/java/com/example/sopt_seminar/domain/usecase/SignUpUseCase.kt
@@ -2,7 +2,6 @@ package com.example.sopt_seminar.domain.usecase
 
 import com.example.sopt_seminar.domain.repository.UserRepository
 import javax.inject.Inject
-import com.example.sopt_seminar.domain.state.Result
 
 class SignUpUseCase @Inject constructor(
     private val userRepository: UserRepository
@@ -11,7 +10,7 @@ class SignUpUseCase @Inject constructor(
         userName: String,
         userEmail: String,
         userPassword: String
-    ): Result = userRepository.signUp(
+    ): Result<String> = userRepository.signUp(
         userName,
         userEmail,
         userPassword

--- a/app/src/main/java/com/example/sopt_seminar/domain/usecase/ValidateTextUseCase.kt
+++ b/app/src/main/java/com/example/sopt_seminar/domain/usecase/ValidateTextUseCase.kt
@@ -1,19 +1,27 @@
 package com.example.sopt_seminar.domain.usecase
 
-import com.example.sopt_seminar.domain.state.Result
 import java.util.regex.Pattern
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class ValidateTextUseCase @Inject constructor() {
-    operator fun invoke(idText: String, passwordText: String, nameText: String = "로그인"):Result{
-        return when{
-            nameText.isEmpty() -> Result.Fail("이름을 입력해주세요")
-            !Pattern.matches("^[가-힣]*\$", nameText) -> Result.Fail("유효한 이름을 입력해주세요")
-            idText.isEmpty() -> Result.Fail("아이디를 입력해주세요")
-            !Pattern.matches("^[a-zA-Z0-9]*\$", idText) -> Result.Fail("유효한 아이디를 입력해주세요")
-            passwordText.isEmpty() -> Result.Fail("비밀번호를 입력해주세요")
-            !Pattern.matches("^(?=.*[a-zA-Z0-9])(?=.*[a-zA-Z!@#\$%^&*])(?=.*[0-9!@#\$%^&*]).{8,15}\$", passwordText) -> Result.Fail("유효한 비밀번호를 입력해주세요")
-            else -> Result.Success(null)
+    operator fun invoke(
+        idText: String,
+        passwordText: String,
+        nameText: String = "로그인"
+    ): Flow<String?> = flow {
+        when {
+            nameText.isEmpty() -> emit("이름을 입력해주세요")
+            !Pattern.matches("^[가-힣]*\$", nameText) -> emit("유효한 이름을 입력해주세요")
+            idText.isEmpty() -> emit("아이디를 입력해주세요")
+            !Pattern.matches("^[a-zA-Z0-9]*\$", idText) -> emit("유효한 아이디를 입력해주세요")
+            passwordText.isEmpty() -> emit("비밀번호를 입력해주세요")
+            !Pattern.matches(
+                "^(?=.*[a-zA-Z0-9])(?=.*[a-zA-Z!@#\$%^&*])(?=.*[0-9!@#\$%^&*]).{8,15}\$",
+                passwordText
+            ) -> emit("유효한 비밀번호를 입력해주세요")
+            else -> emit(null)
         }
     }
 }

--- a/app/src/main/java/com/example/sopt_seminar/ui/profile/followerlist/FollowerListViewModel.kt
+++ b/app/src/main/java/com/example/sopt_seminar/ui/profile/followerlist/FollowerListViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.sopt_seminar.domain.model.Follower
-import com.example.sopt_seminar.domain.state.Result
 import com.example.sopt_seminar.domain.usecase.GetFollowerListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -21,27 +20,16 @@ class FollowerListViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            getFollowerListUseCase().collect { result ->
-                when (result) {
-                    is Result.Uninitialized -> {
-                        Log.d("asdfasdfs","viewmodel Uninitialized")
-                        emitEvent(FollowerListEvent.Loading)
-                    }
-                    is Result.Success<*> -> {
-                        Log.d("asdfasdfs","viewmodel Success")
-                        emitEvent(FollowerListEvent.FollowerList(result.data as List<Follower>))
-                    }
-                    is Result.Fail<*> -> {
-                        emitEvent(FollowerListEvent.ShowToast(result.msg.toString()))
-                    }
-                }
+            runCatching {
+                getFollowerListUseCase()
+                    .onSuccess { emitEvent(FollowerListEvent.FollowerList(it)) }
+                    .onFailure { error -> Log.d("FollowerListViewModel", error.message.toString()) }
             }
         }
     }
 
     private fun emitEvent(event: FollowerListEvent) {
         viewModelScope.launch {
-            Log.d("asdfasdfs","viewmodel emit")
             _eventFlow.emit(event)
         }
     }


### PR DESCRIPTION
## 커스텀 Result에서 코틀린 Result로 변경
### 느낀점
- Repository 코드가 줄어든 것이 제일 먼저 눈에 띄고 또, 가독성이 더 좋아진 것 같다
- Custom Result는 이제 안 만들 것 같다
- 통신을 할 때 꼭 `Response<>`를 감쌌었는데 이번에 안 감싸고 구현해보니 if 문이 한 줄 더 줄어 들어서 보기 좋아진 것 같다. 서버 명세서 API를 확인하고 감쌀 필요가 없다면 안 감싸는 방향으로 코드를 짜야겠다.

### 어려웠던 점
리팩토링 초반에 로그인 과정에서 (`1. 로그인을 성공할 때` , `2. 유저 정보를 찾을 수 없을 때`, `3. 비밀번호가 올바르지 않을 때`) 모두 CommonResponse 안에 값이 들어오니까 3가지 상황 모두 onSuccess 안에 들어오는 줄 알아서 onSuccess 안에서 분기 처리를 위해서 따로 Sealed Class를 만들었는데 이전 커스텀 Result와 다를게 없어서 어떻게 해야 되나 머리가 아팠다.

하지만 로그를 찍어보니까 `로그인 성공하는 상황`을 제외하고 2, 3번 상황이 생길 땐 알아서 onFailure로 들어갔고, 디스코드에서 알아서 onFailure로 들어간다는 말이 이 말 이였구나 생각했다

또, 이제 onFaliure 에서 2, 3번 상황의 분기 처리를 어떻게 할까 고민이었는데, 그냥 `error message`로 구분했다. 근데 이 방식이 괜찮은 방식인지 모르겠다
### 궁금한 점

1. `SignInViewModel`, `SignUpViewModel` 에선 유효성 검사를 먼저 하고, 유효성 검사 결과가 `null` 값이 나오면 회원 정보를 비교한 후 `runCatching`을 시작한다. 그래서 tab을 너무 많이 사용해서 가독성이 떨어지는 것 같다. 어떤 식으로 리팩토링해야 할지 방향을 못 잡겠다.

```kotlin
viewModelScope.launch {
    validateTextUseCase(idText.value, pwText.value).collect { msg ->
        if (msg != null) emitEvent(Event.ShowToast(msg))
        else {
            runCatching {
                signInUseCase(idText.value, pwText.value)
                    .onSuccess { msg ->
                        emitEvent(Event.ShowToast(msg))
                        emitEvent(Event.IsFinish)
                    }
                   .onFailure { error -> emitEvent(Event.ShowToast(error.message.toString())) }
          }
      }
   }
}
```

2. SignInViewModel 내에서
```kotlin
runCatching{
    signInUseCase(idText.value, pwText.value)
        .onSuccess{ msg->
            emitEvent(Event.ShowToast(msg))
	    emitEvent(Event.IsFinish)
	}
	.onFailure{ error->emitEvent(Event.ShowToast(error.message.toString()))}
}
```
위와 같은 방식 말고

```kotlin
runCatching{ signInUseCase(idText.value, pwText.value).getOrNull() }
    .onSuccess{ msg->
        emitEvent(Event.ShowToast(msg))
	emitEvent(Event.IsFinish)
    }
    .onFailure{error->emitEvent(Event.ShowToast(error.message.toString()))}
```
tab이 줄어들어서 아래와 같은 방식으로 코드를 작성하고 싶은데, 아래와 같은 방식으로 `getOrNull()`을 사용하면, 404 에러가 발생할 때 `Repository`에선 `onFailure` 로 잘 들어가더라도  `SignInViewModel` 안에는 null 값이 들어와서 로그인이 성공한다. 
아래 같은 방식 못하는 건지 궁금하다.

3. 
```kotlin
override suspend fun getFollowerList(): Result<List<Follower>> {
	runCatching{ userRemoteDataSource.getFollowerList() }
		.onSuccess{response->
			return Result.success(response.body()!!.map{followerEntity->followerEntity.toFollower()})
		}
		.onFailure{return Result.failure(Throwable(it))}
	return Result.failure(Throwable("what the...f"))
}
```
통신을 하면 성공, 실패 2개의 조건 밖에 없다고 생각해서 `onSuccess`, `onFailure` 안에서 `return `해줘도 충분하다고 생각했는데, 왜 마지막에 `return Result<>`을 또 해줘야 하는지 모르겠다.


4. 
원래 목적은 Repository 별로 Unit Test를 먼저 작성한 다음에 리팩토링을 해보려고 했는데, 어떻게 작성해야 되는지 모르겠고 막상 하려니 귀찮아서 그냥 리팩토링했다... TDD는 다음에...

### 나중에 할 것
- [ ] GitHub follower List 통신하는 동안 Loading 화면 보이도록 구현하기 
- [ ] TDD